### PR TITLE
docs: fix some markdown, add GitHub link

### DIFF
--- a/docs/ko/intro.md
+++ b/docs/ko/intro.md
@@ -7,7 +7,7 @@ TanStack Query 라이브러리를 밑바닥부터 구현하는 방법을 소개�
 ## 목표
 
 - TanStack Query의 동작 흐름을 알아봅니다.
-  -React 환경에서 TanStack Query를 사용하는 방법을 알아봅니다.
+- React 환경에서 TanStack Query를 사용하는 방법을 알아봅니다.
 
 ## 개발 환경 구성하기
 
@@ -24,7 +24,7 @@ npm run dev
 
 ## 최종 결과 확인하기
 
-구현된 코드는 Github에서 확인하실 수 있습니다.
+구현된 코드는 [GitHub](https://github.com/mugglim/build-your-own-tanstack-query)에서 확인하실 수 있습니다.
 
 <video width="100%" height="240" controls>
   <source src="/demo.mov" type="video/mp4">


### PR DESCRIPTION
## 변경 사항
- 마크다운 문법 수정
- `github` → `GitHub` 정식 표기로 수정
- 브랜드 가이드라인에 맞춰 대소문자 통일
- 링크 추가

## 변경 이유
- GitHub의 공식 브랜딩은 'GitHub'로 첫 글자와 'H'를 대문자로 표기
- 브랜드 일관성
- 링크 추가로 접근성 및 편의성 향상


----------

## What Changed
- Fix markdown
- Updated `github` → `GitHub` to match official brand styling
- Standardized capitalization across documentation
- Added relevant links

## Why These Changes
- GitHub's official brand guideline requires 'GitHub' capitalization
- Ensures brand consistency throughout documentation
- Enhanced accessibility and user convenience with additional links